### PR TITLE
Remove x509 dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "islandis-login",
-  "version": "1.0.5",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -18,11 +18,6 @@
         "tweetnacl": "^1.0.1"
       }
     },
-    "nan": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.0.tgz",
-      "integrity": "sha512-zT5nC0JhbljmyEf+Z456nvm7iO7XgRV2hYxoBtPpnyp+0Q4aCoP6uWNn76v/I6k2kCYNLWqWbwBWQcjsNI/bjw=="
-    },
     "prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
@@ -38,14 +33,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-    },
-    "x509": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/x509/-/x509-0.3.4.tgz",
-      "integrity": "sha512-in6y2bl0kGHDMG4rD4Zzu5UH/4wAIiTXNwlrVOhBCyDptQmUujDHy0O60y8Nalb/p4Y0nsIbg70amKrCyZC9Ew==",
-      "requires": {
-        "nan": "2.12.0"
-      }
     },
     "xml-crypto": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "homepage": "https://github.com/mojoweb/islandis-login#readme",
     "dependencies": {
         "@fidm/x509": "^1.2.1",
-        "x509": "^0.3.4",
         "xml-crypto": "^1.4.0",
         "xml2js": "^0.4.23",
         "xmldom": "^0.3.0"


### PR DESCRIPTION
I've removed the dependency on x509, since we're getting node-gyp issues on Mojave. Since this package is already using the pure javascript @fidm/x509 package, I see no need for the x509 dependency anyway. I also did some minor renames, just for brevity. Hope this is okay, and thank you for this package!