### PR TITLE
Support overriding path to certificate file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,7 @@ declare module 'islandis-login' {
     }: {
       verifyDates?: boolean;
       audienceUrl: string | null;
+      certificatePath?: string;
     })
 
     verify(token: string): Promise<VerifyResult>;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 const { parseStringPromise } = require("xml2js");
 const { validateCert } = require("./src/validateSignature.js");
+const path = require("path");
 
 const IslandISLogin = function() {
     const defaults = {
         verifyDates: true,
         audienceUrl: null,
+        certificatePath: undefined,
     };
 
     // Create options by extending defaults with the passed in arguments
@@ -28,7 +30,8 @@ const IslandISLogin = function() {
                     // Validate signature of XML document from Island.is, verify that the
                     // XML document was signed by Island.is and verify certificate issuer.
                     try {
-                        await validateCert(xml, x509signature);
+                        const certPath = this.options.certificatePath || path.resolve(__dirname, "./cert/FullgiltAudkenni.pem");
+                        await validateCert(xml, x509signature, certPath);
                     } catch (e) {
                         return reject({
                             id: "CERTIFICATE-INVALID",

--- a/src/validateSignature.js
+++ b/src/validateSignature.js
@@ -60,10 +60,10 @@ function checkSignature(doc, pem, xml) {
     return isValid;
 }
 
-function isCertificateValid(certificate) {
+function isCertificateValid(certificate, certPath) {
     // Reference: https://www.audkenni.is/adstod/skilriki-kortum/skilrikjakedjur/
     const certFromPem = Certificate.fromPEM(
-        readFileSync(path.resolve(__dirname, "../cert/FullgiltAudkenni.pem"))
+        readFileSync(certPath)
     );
 
     // we only need to verify the authority cert because that is the cert used
@@ -90,7 +90,7 @@ function certToPEM(cert) {
     and validates digital signature of XML.
 
 */
-function validate(xml, signature) {
+function validate(xml, signature, certPath) {
     return new Promise((resolve, reject) => {
         const doc = new DOMParser().parseFromString(xml);
 
@@ -112,7 +112,7 @@ function validate(xml, signature) {
 
         // Verify that the certificate we get from the Island.is request
         // is signed and issued by Traustur Bunadur certificate.
-        if (!isCertificateValid(cert)) {
+        if (!isCertificateValid(cert, certPath)) {
             return reject(
                 "The XML document is not signed by Þjóðskrá Íslands."
             );


### PR DESCRIPTION
Adds a configuration option to override the default certificate path. Useful if you wanna organize your project structure differently.